### PR TITLE
error: create is now default behaviour of module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,32 +1,12 @@
 'use strict';
 
-var _ = require('lodash');
-var assert = require('assert');
-var util = require('util');
+var create = require('./lib/custom-error');
 
-/**
- * Create a new Error constructor.
- * @param {string} name - The name of your error.
- * @param {string=} code - The code of your error.
- * @param {Function=} ext - An initializer function for altering the custom
- * Error's behaviour (such as modifying the message, code, or adding custom
- * values to the object).
- * @returns {Function} Constructor function for custom Error.
- */
-exports.create = function(name, code, ext) {
-  assert(name, 'A name must be provided to generate a new Error type.');
-  function CustomError(message) {
-    if (!Error.captureStackTrace) // IE...
-      this.stack = (new Error()).stack;
-    else
-      Error.captureStackTrace(this, this.constructor);
-    this.message = message;
-    if (ext && ext instanceof Function)
-      ext.apply(this, arguments);
-  }
-  CustomError.prototype = new Error();
-  CustomError.prototype.name = name;
-  CustomError.prototype.code = code || 'ERR';
-  CustomError.prototype.constructor = CustomError;
-  return CustomError;
-};
+module.exports = Handlerr;
+
+function Handlerr(name, code, ext) {
+  if (name)
+    return create(name, code, ext);
+}
+
+Handlerr.create = create;

--- a/lib/custom-error.js
+++ b/lib/custom-error.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var _ = require('lodash');
+var assert = require('assert');
+var util = require('util');
+
+/**
+ * Create a new Error constructor.
+ * @param {string} name - The name of your error.
+ * @param {string=} code - The code of your error.
+ * @param {Function=} ext - An initializer function for altering the custom
+ * Error's behaviour (such as modifying the message, code, or adding custom
+ * values to the object).
+ * @returns {Function} Constructor function for custom Error.
+ */
+module.exports = function(name, code, ext) {
+  assert(name, 'A name must be provided to generate a new Error type.');
+  function CustomError(message) {
+    if (!Error.captureStackTrace) // IE...
+      this.stack = (new Error()).stack;
+    else
+      Error.captureStackTrace(this, this.constructor);
+    this.message = message;
+    if (ext && ext instanceof Function)
+      ext.apply(this, arguments);
+  }
+  CustomError.prototype = new Error();
+  CustomError.prototype.name = name;
+  CustomError.prototype.code = code || 'ERR';
+  CustomError.prototype.constructor = CustomError;
+  return CustomError;
+};

--- a/test/test-custom-error.js
+++ b/test/test-custom-error.js
@@ -4,11 +4,28 @@ var fmt = require('util').format;
 var handlerr = require('../index');
 var tap = require('tap');
 
-tap.test('Creation testing', function (t) {
+tap.test('Custom Error testing', function (t) {
   t.test('error function - default handler', function(t) {
     var message = 'Why did you DO that!?';
     var code = 'SILLY';
     var SillyError = handlerr.create('SillyError', code);
+
+    try {
+      throw new SillyError(message);
+      t.fail('No error was thrown!');
+    } catch (err) {
+      t.equal(err.message, message, 'provided message returned');
+      t.equal(err.code, code, 'provided code returned');
+      t.ok(err.stack, 'error has a stack trace');
+      t.type(err, SillyError, 'error is correct type');
+    }
+    t.end();
+  });
+
+  t.test('error function - quick create', function(t) {
+    var message = 'Why did you DO that!?';
+    var code = 'SILLY';
+    var SillyError = handlerr('SillyError', code);
 
     try {
       throw new SillyError(message);


### PR DESCRIPTION
-    Move custom error creation to own module
-    Refactor index to allow creation both with `handlerr('name', 'code')` and `handlerr.create('name', 'code')`
