### PR TITLE
Revert "ci: travis config"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - "5"
-  - "4"
-  - "0.12"


### PR DESCRIPTION
Reverts kjdelisle/handlerr#1

Config not necessary; the defaults already run these builds
